### PR TITLE
Fix typo in loading of ORL dataset

### DIFF
--- a/code/01_data_collection/get_datasets.py
+++ b/code/01_data_collection/get_datasets.py
@@ -427,8 +427,8 @@ def process_orl():
         for j in range(10):
             tmp = io.imread(dir_name + '/%d.pgm' % (j + 1))
             tmp = transform.resize(tmp, (img_h, img_w), preserve_range=True)
-            X[i] = tmp / 255.0
-            y[i] = label
+            X[10 * i + j] = tmp / 255.0
+            y[10 * i + j] = label
 
     save_dataset('orl', X.reshape((-1, img_h * img_w)), y)
 


### PR DESCRIPTION
I am a member of Stephen Kobourov's research team and we found your repository highly useful for our research. While working with the repository, I encountered a small bug that resulted in only part of the ORL dataset being loaded.

The _process_orl()_ function had an error where only 40 of the 400 images were being saved, and the rest of the 360 images were stored as null-vectors. The issue was in the for loop, where information about images of the same label were being written onto the same location in the numpy arrays. This resulted in a dataset with only 40 vectors with useful information and 360 null-vectors.

I am more than happy to discuss further if you have any questions.